### PR TITLE
add the ability to run imperatively via flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+component-generator

--- a/Makefile
+++ b/Makefile
@@ -66,13 +66,13 @@ generate-file: ## Generate an aggregate component-definition.yaml file
 generate-stdout: ## Generate Go structs from OSCAL JSON schema and output to stdout
 	./bin/component-generator aggregate test/input/components.yaml
 
+.PHONY: generate-imperative
+generate-imperative: ## Generate Go structs from OSCAL JSON schema and output to stdout
+	./bin/component-generator aggregate aggregate -r https://repo1.dso.mil/big-bang/apps/core/kiali.git/oscal-component.yaml@1.60.0-bb.2 -v 1.0.0 -t component-title -n my-file.yaml -l ./test/input/jaeger-component-definition.yaml 
+
 .PHONY: test
 test: build ## Run automated tests.
 	go test $(GOFLAGS) -run $(TESTS) $(PKG) $(TESTFLAGS)
-
-.PHONY: run-main
-run-main: ## useful for running the main.go file without having to compile
-	go run main.go aggregate test/input/components.yaml
 
 .PHONY: install
 install: ## Install binary to $INSTALL_PATH.


### PR DESCRIPTION
There will be a use-case for implementation in CICD where the user may not want to have a declarative file stored (Additional references that will need to be kept up-to-date) in the repository and they may just want the ability to orchestrate the changes imperatively.

This adds flags to the aggregate command to support defining all necessary information as such.