### PR TITLE
Artifact diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 
 component-generator
+my-generated-file.yaml

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ components:
 
 The command should always default to the name provided in the configuration - unless it is empty
 
+#### Diff detection
+As we perform the generation - the runtime is not idempotent - as time will change after each invocation (same for UUID)
+
+Can we generate the document and then perform a diff if there is an existing document present?
+
 #### Hashes
 Add functionality after aggregation is stable to allow the hash identification of the file in the declaration.
 IE:

--- a/src/cmd/aggregate.go
+++ b/src/cmd/aggregate.go
@@ -113,10 +113,12 @@ func run(commandArgs []string) {
 		}
 	}
 
-	yamlDoc, err := component.BuildOscalDocument(config)
+	yamlDoc, oscalObj, err := component.BuildOscalDocument(config)
 	if err != nil {
 		log.Fatal(err)
 	}
+	fmt.Println(oscalObj)
+	// perform a diff here
 
 	if !stdout {
 		err := os.WriteFile(config.Name, []byte(yamlDoc), 0644)

--- a/src/cmd/aggregate.go
+++ b/src/cmd/aggregate.go
@@ -65,7 +65,7 @@ func run(commandArgs []string) {
 		if title == "" {
 			log.Fatal("Title is Required")
 		}
-		if title == "" {
+		if name == "" {
 			log.Fatal("Name is Required")
 		}
 		if len(remotes) == 0 && len(locals) == 0 {
@@ -117,16 +117,52 @@ func run(commandArgs []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Println(oscalObj)
-	// perform a diff here
-
-	if !stdout {
-		err := os.WriteFile(config.Name, []byte(yamlDoc), 0644)
+	_, error := os.Stat(config.Name)
+	if error == nil {
+		// if the file exists - read/unmarshall and compare
+		fmt.Println("File exists - running comparison")
+		var existingObj types.OscalComponentDocument
+		rawExist, err := os.ReadFile(config.Name)
 		if err != nil {
-			log.Fatalf("writing output: %s", err)
+			log.Fatal(err)
 		}
+
+		err = yaml.Unmarshal(rawExist, &existingObj)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Document now exists - compare
+
+		unmodified := component.DiffComponentObjects(existingObj, oscalObj)
+
+		if unmodified {
+			// If not modified, no need to write new file
+			fmt.Println("No fields have been updated - not updating document")
+			if stdout {
+				fmt.Print(string(yamlDoc))
+			}
+		} else {
+			if !stdout {
+				err := os.WriteFile(config.Name, []byte(yamlDoc), 0644)
+				if err != nil {
+					log.Fatalf("writing output: %s", err)
+				}
+			} else {
+				fmt.Print(string(yamlDoc))
+			}
+		}
+
 	} else {
-		fmt.Print(string(yamlDoc))
+		fmt.Println("File does not exist - running output")
+		if !stdout {
+			err := os.WriteFile(config.Name, []byte(yamlDoc), 0644)
+			if err != nil {
+				log.Fatalf("writing output: %s", err)
+			}
+		} else {
+			fmt.Print(string(yamlDoc))
+		}
 	}
 
 }

--- a/src/pkg/component/component.go
+++ b/src/pkg/component/component.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func BuildOscalDocument(config types.ComponentsConfig) (string, error) {
+func BuildOscalDocument(config types.ComponentsConfig) (string, types.OscalComponentDocument, error) {
 	var (
 		backMatterResources = []types.Resources{}
 		components          = []types.DefinedComponent{}
@@ -23,7 +23,7 @@ func BuildOscalDocument(config types.ComponentsConfig) (string, error) {
 	for _, local := range config.Components.Locals {
 		document, err := oscal.GetOscalComponentFromLocal(local.Name)
 		if err != nil {
-			return "", err
+			return "", types.OscalComponentDocument{}, err
 		}
 		documents = append(documents, document)
 	}
@@ -64,9 +64,9 @@ func BuildOscalDocument(config types.ComponentsConfig) (string, error) {
 
 	yamlDocBytes, err := yaml.Marshal(aggregateOscalDocument)
 	if err != nil {
-		return "", err
+		return "", aggregateOscalDocument, err
 	}
-	return string(yamlDocBytes), nil
+	return string(yamlDocBytes), aggregateOscalDocument, nil
 }
 
 // generateUUID generates UUIDs

--- a/src/pkg/component/component.go
+++ b/src/pkg/component/component.go
@@ -3,6 +3,7 @@ package component
 import (
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 	"time"
 
@@ -67,6 +68,19 @@ func BuildOscalDocument(config types.ComponentsConfig) (string, types.OscalCompo
 		return "", aggregateOscalDocument, err
 	}
 	return string(yamlDocBytes), aggregateOscalDocument, nil
+}
+
+func DiffComponentObjects(origObj types.OscalComponentDocument, newObj types.OscalComponentDocument) bool {
+	// Compare the metadata structs and the list of components
+	// in-scope set LastModified to empty string to remove it from consideration
+	origObj.ComponentDefinition.Metadata.LastModified = ""
+	newObj.ComponentDefinition.Metadata.LastModified = ""
+
+	metaCompare := reflect.DeepEqual(origObj.ComponentDefinition.Metadata, newObj.ComponentDefinition.Metadata)
+
+	childCompare := reflect.DeepEqual(origObj.ComponentDefinition.Components, newObj.ComponentDefinition.Components)
+
+	return childCompare && metaCompare
 }
 
 // generateUUID generates UUIDs


### PR DESCRIPTION
Adding the ability to perform a diff of artifacts when an existing file is present. Preventing the need to update the entire document (to include UUID) when nothing has been changed - to include checking the children that were aggregated into the artifact.