### PR TITLE
Draft: Metadata aggregate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,15 +60,15 @@ $(BINDIR)/$(BINNAME): $(SRC)
 
 .PHONY: generate-file
 generate-file: ## Generate an aggregate component-definition.yaml file
-	./bin/component-generator aggregate test/input/components.yaml
+	./bin/component-generator aggregate -i test/input/components.yaml
 
 .PHONY: generate-stdout
-generate-stdout: ## Generate Go structs from OSCAL JSON schema and output to stdout
-	./bin/component-generator aggregate test/input/components.yaml
+generate-stdout: ## Generate aggregate file to stdout
+	./bin/component-generator aggregate -i test/input/components.yaml
 
 .PHONY: generate-imperative
-generate-imperative: ## Generate Go structs from OSCAL JSON schema and output to stdout
-	./bin/component-generator aggregate aggregate -r https://repo1.dso.mil/big-bang/apps/core/kiali.git/oscal-component.yaml@1.60.0-bb.2 -v 1.0.0 -t component-title -n my-file.yaml -l ./test/input/jaeger-component-definition.yaml 
+generate-imperative: ## Generate aggregate file OSCAL document imperatively
+	./bin/component-generator aggregate -r https://repo1.dso.mil/big-bang/apps/core/kiali.git/oscal-component.yaml@1.60.0-bb.2 -v 1.0.0 -t component-title -n my-file.yaml -l ./test/input/jaeger-component-definition.yaml 
 
 .PHONY: test
 test: build ## Run automated tests.

--- a/src/pkg/component/component.go
+++ b/src/pkg/component/component.go
@@ -48,6 +48,16 @@ func BuildOscalDocument(config types.ComponentsConfig) (string, types.OscalCompo
 	for _, doc := range documents {
 		components = append(components, doc.ComponentDefinition.Components...)
 		backMatterResources = append(backMatterResources, doc.ComponentDefinition.BackMatter.Resources...)
+
+		// Begin metadata aggregation to top-level metadata
+		config.Metadata.DocumentIds = append(config.Metadata.DocumentIds, doc.ComponentDefinition.Metadata.DocumentIds...)
+		config.Metadata.Links = append(config.Metadata.Links, doc.ComponentDefinition.Metadata.Links...)
+		config.Metadata.Roles = append(config.Metadata.Roles, doc.ComponentDefinition.Metadata.Roles...)
+		config.Metadata.Parties = append(config.Metadata.Parties, doc.ComponentDefinition.Metadata.Parties...)
+		config.Metadata.Props = append(config.Metadata.Props, doc.ComponentDefinition.Metadata.Props...)
+		config.Metadata.Locations = append(config.Metadata.Locations, doc.ComponentDefinition.Metadata.Locations...)
+		config.Metadata.ResponsibleParties = append(config.Metadata.ResponsibleParties, doc.ComponentDefinition.Metadata.ResponsibleParties...)
+		config.Metadata.Revisions = append(config.Metadata.Revisions, doc.ComponentDefinition.Metadata.Revisions...)
 	}
 
 	config.Metadata.LastModified = rfc3339Time

--- a/test/input/jaeger-component-definition.yaml
+++ b/test/input/jaeger-component-definition.yaml
@@ -11,7 +11,7 @@ component-definition:
       type: organization
       name: Platform One
       links:
-      - href: <https://p1.dso.mil>
+      - href: https://p1.dso.mil
         rel: website
   components:
   - uuid: 50EE9EB1-0DA4-411C-8771-AA1725B27E22


### PR DESCRIPTION
Adding logic to aggegrate all children metadata fields that are arrays into the parent metadata - nothing is lost - but this will hopefully allow visibility into what fields are relevant and what context might be lost.